### PR TITLE
Update guide with Docker instructions

### DIFF
--- a/doc/2-guide.text
+++ b/doc/2-guide.text
@@ -99,31 +99,31 @@ you get started.
 To build a docker image from the `Dockerfile`, we use `docker build`:
 
 ``` {.bash}
-docker build \
-  --target <target> `# Select a target from the Dockerfile \
-  -t <tag>          `# Set a tag for the resulting image \
-  - < Dockerfile    `# Read the Dockerfile from stdin
+docker build --target <target> -t <tag> .
 ```
+
+Here `<target>` selects the target from the `Dockerfile`, `<tag>` sets the tag
+for the resulting image, and the `.` sets the build context to the current
+working directory.
 
 Run `docker build` three times to build the required images:
 
 -   `spark-submit`
 
     ``` {.bash}
-    docker build --target spark-submit -t spark-submit - < Dockerfile
+    docker build --target spark-submit -t spark-submit .
     ```
 
 -   `spark-shell`
 
     ``` {.bash}
-    docker build --target spark-shell -t spark-shell - < Dockerfile
+    docker build --target spark-shell -t spark-shell .
     ```
 
 -   `spark-history-server`
 
     ``` {.bash}
-    docker build --target spark-history-server -t spark-history-server - <
-    Dockerfile
+    docker build --target spark-history-server -t spark-history-server .
     ```
 
 You can then run the following commands from the Spark application root

--- a/doc/2-guide.text
+++ b/doc/2-guide.text
@@ -289,21 +289,22 @@ github version, and use the `:paste` command in the spark shell to paste the
 code. Hit `ctrl+D` to stop pasting._
 
 ``` {.scala}
-$ spark-shell
-2018-08-29 12:56:07 WARN  NativeCodeLoader:62 - Unable to load native-hadoop...
+$ docker run -it --rm -v `pwd`:/io spark-shell
+19/09/08 14:00:48 WARN NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
+Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
 Setting default log level to "WARN".
-To adjust logging level use sc.setLogLevel(newLevel). For SparkR,...
-Spark context Web UI available at http://
-Spark context available as 'sc' (master = local[*], app id = local-1535540172727).
+To adjust logging level use sc.setLogLevel(newLevel). For SparkR, use setLogLevel(newLevel).
+Spark context Web UI available at http://af29447c6dcd:4040
+Spark context available as 'sc' (master = local[*], app id = local-1567951261349).
 Spark session available as 'spark'.
 Welcome to
       ____              __
      / __/__  ___ _____/ /__
     _\ \/ _ \/ _ `/ __/  '_/
-   /___/ .__/\_,_/_/ /_/\_\   version 2.3.1
+   /___/ .__/\_,_/_/ /_/\_\   version 2.4.4
       /_/
 
-Using Scala version 2.11.8 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_102)
+Using Scala version 2.11.12 (OpenJDK 64-Bit Server VM, Java 1.8.0_222)
 Type in expressions to have them evaluated.
 Type :help for more information.
 
@@ -721,12 +722,9 @@ The project's name, dependencies, and versioning is defined in the `build.sbt`
 file. An example `build.sbt` file is
 
 ```
-ThisBuild / scalaVersion := "2.11.12"
+name := "Example"
 
-lazy val example = (project in file("."))
-  .settings(
-    name := "Example project",
-  )
+scalaVersion := "2.11.12"
 ```
 
 This specifies the Scala version of the project (2.11.12) and the name of the
@@ -749,27 +747,30 @@ object Example {
 }
 ```
 
-Run `sbt` in the root folder (the one where `build.sbt` is located). This puts
+Start a `scala-sbt` container in the root folder (the one where `build.sbt` is located). This puts
 you in interactive mode of SBT. We can compile the sources by writing the
 `compile` command.
 
 ```
-$ sbt
-[info] Loading project definition from ...
-[info] Loading settings for project hello from build.sbt ...
-[info] Set current project to Example project ...
-[info] sbt server started at ...
-sbt:Example project> compile
-[success] Total time: 0 s, completed Sep 3, 2018 1:56:10 PM
+$ docker run -it --rm -v `pwd`:/root hseeberger/scala-sbt sbt
+Getting org.scala-sbt sbt 1.2.8  (this may take some time)...
+...
+[info] Loading settings for project root from build.sbt ...
+[info] Set current project to Example (in build file:/root/)
+[info] sbt server started at local:///root/.sbt/1.0/server/27dc1aa3fdf4049b492d/sock
+sbt:Example> compile
+...
+[info] Done compiling.
+[success] Total time: 0 s, completed Sep 8, 2019 2:17:14 PM
 ```
 
 We can try to run the application by typing `run`.
 
 ```
-sbt:Example project> run
+sbt:Example> run
 [info] Running example.Example
 Hello world!
-[success] Total time: 1 s, completed Sep 3, 2018 2:00:08 PM
+[success] Total time: 1 s, completed Sep 8, 2019 2:18:18 PM
 ```
 
 Now let's add a function to `example.scala`.
@@ -790,7 +791,7 @@ In your SBT session we can prepend any command with a tilde (`~`) to make them
 run automatically on source changes.
 
 ```
-sbt:Example project> ~run
+sbt:Example> ~run
 [info] Compiling 1 Scala source to ...
 [info] Done compiling.
 [info] Packaging ...
@@ -798,16 +799,16 @@ sbt:Example project> ~run
 [info] Running example.Example
 Hello world!
 (a,2)
-[success] Total time: 1 s, completed Sep 3, 2018 2:02:48 PM
+[success] Total time: 1 s, completed Sep 8, 2019 2:19:03 PM
 1. Waiting for source changes in project hello... (press enter to interrupt)
 ```
 
 We can also open an interactive session using SBT.
 
 ```
-sbt:Example project> console
+sbt:Example> console
 [info] Starting scala interpreter...
-Welcome to Scala 2.11.12 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_102).
+Welcome to Scala 2.11.12 (OpenJDK 64-Bit Server VM, Java 1.8.0_222).
 Type in expressions for evaluation. Or try :help.
 
 scala> example.Example.addOne('a', 1)
@@ -821,15 +822,16 @@ To build Spark applications with SBT we need to include dependencies (Spark
 most notably) to build the project. Modify your `build.sbt` file like so
 
 ```
-ThisBuild / scalaVersion := "2.11.12"
+name := "Example"
 
-lazy val example = (project in file("."))
-  .settings(
-    name := "Example project",
+scalaVersion := "2.11.12"
 
-    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.3.1",
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.3.1"
-  )
+val sparkVersion = "2.4.4"
+
+libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core" % sparkVersion,
+  "org.apache.spark" %% "spark-sql" % sparkVersion
+)
 ```
 
 We can now use Spark in the script. Modify `example.scala`.
@@ -894,10 +896,13 @@ object ExampleSpark {
 You can build a JAR using the `package` command in SBT. This JAR will be
 located in the `target/scala-version/project_name_version.jar`.
 
-You can run the JAR via `spark-submit` (which will run on local mode).
+You can run the JAR via a `spark-submit` container (which will run on local
+mode). By mounting the `spark-events` directory the event log of the
+application run is stored to be inspected later using the Spark history server.
 
 ```
-$ spark-submit target/scala-2.11/example-project_2.11-0.1.0-SNAPSHOT.jar
+$ docker run -it --rm -v `pwd`:/io -v `pwd`/spark-events:/spark-events
+    spark-submit target/scala-2.11/example_2.11-0.1.0-SNAPSHOT.jar
 INFO:...
 SensorData(COHUTTA,2014-03-10 01:01:00.0,10.27,1.73,881,1.56,85,1.94)
 SensorData(NANTAHALLA,2014-03-10 01:01:00.0,10.47,1.712,778,1.96,76,0.78)
@@ -937,6 +942,52 @@ def main(args: Array[String]) {
 You can also use this logger to log your application which might be helpful for
 debugging on the AWS cluster later on.
 
+You can inspect the event log from the application run using the  Spark history
+server. Start a `spark-history-server` container from the project root folder
+and mount the `spark-events` folder in the container.
+
+```
+$ docker run -it --rm -v `pwd`/spark-events/:/spark-events -p 18080:18080
+    spark-history-server
+starting org.apache.spark.deploy.history.HistoryServer, logging to /spark/logs/spark--org.apache.spark.deploy.history.HistoryServer-1-d5dfa4949b86.out
+Spark Command: /usr/local/openjdk-8/bin/java -cp /spark/conf/:/spark/jars/*
+  -Xmx1g org.apache.spark.deploy.history.HistoryServer
+========================================
+Using Spark's default log4j profile: org/apache/spark/log4j-defaults.properties
+19/09/08 14:25:33 INFO HistoryServer: Started daemon with process name:
+  14@d5dfa4949b86
+19/09/08 14:25:33 INFO SignalUtils: Registered signal handler for TERM
+19/09/08 14:25:33 INFO SignalUtils: Registered signal handler for HUP
+19/09/08 14:25:33 INFO SignalUtils: Registered signal handler for INT
+19/09/08 14:25:34 WARN NativeCodeLoader: Unable to load native-hadoop library
+  for your platform... using builtin-java classes where applicable
+19/09/08 14:25:34 INFO SecurityManager: Changing view acls to: root
+19/09/08 14:25:34 INFO SecurityManager: Changing modify acls to: root
+19/09/08 14:25:34 INFO SecurityManager: Changing view acls groups to:
+19/09/08 14:25:34 INFO SecurityManager: Changing modify acls groups to:
+19/09/08 14:25:34 INFO SecurityManager: SecurityManager: authentication
+  disabled; ui acls disabled; users  with view permissions: Set(root); groups
+     with view permissions: Set(); users  with modify permissions: Set(root);
+      groups with modify permissions: Set()
+19/09/08 14:25:34 INFO FsHistoryProvider: History server ui acls disabled;
+  users with admin permissions: ; groups with admin permissions
+19/09/08 14:25:35 INFO FsHistoryProvider:
+  Parsing file:/spark-events/local-1567952519905 for listing data...
+19/09/08 14:25:35 INFO Utils: Successfully started service on port 18080.
+19/09/08 14:25:35 INFO HistoryServer: Bound HistoryServer to 0.0.0.0,
+  and started at http://d5dfa4949b86:18080
+19/09/08 14:25:36 INFO FsHistoryProvider: Finished parsing
+  file:/spark-events/local-1567952519905
+```
+
+Navigate to <localhost:18080> to view detailed information about your jobs.
+After analysis you can shutdown the Spark history server using ctrl+C.
+
+```
+$ ^C
+19/09/08 14:27:18 ERROR HistoryServer: RECEIVED SIGNAL INT
+19/09/08 14:27:18 INFO ShutdownHookManager: Shutdown hook called
+```
 
   [this article]: https://blog.gdeltproject.org/gdelt-2-0-our-global-world-in-realtime/
   [this table]: https://github.com/linwoodc3/gdelt2HeaderRows/blob/master/schema_csvs/GDELT_2.0_gdeltKnowledgeGraph_Column_Labels_Header_Row_Sep2016.tsv

--- a/doc/2-guide.text
+++ b/doc/2-guide.text
@@ -100,9 +100,9 @@ To build a docker image from the `Dockerfile`, we use `docker build`:
 
 ``` {.bash}
 docker build \
-  --build-target <target> `# Select a target from the Dockerfile \
-  -t <tag>                `# Set a tag for the resulting image \
-  -f Dockerfile          ` # Read the Dockerfile
+  --target <target> `# Select a target from the Dockerfile \
+  -t <tag>          `# Set a tag for the resulting image \
+  - < Dockerfile    `# Read the Dockerfile from stdin
 ```
 
 Run `docker build` three times to build the required images:
@@ -110,19 +110,19 @@ Run `docker build` three times to build the required images:
 -   `spark-submit`
 
     ``` {.bash}
-    docker build --build-target spark-submit -t spark-submit -f Dockerfile
+    docker build --target spark-submit -t spark-submit - < Dockerfile
     ```
 
 -   `spark-shell`
 
     ``` {.bash}
-    docker build --build-target spark-shell -t spark-shell -f Dockerfile
+    docker build --target spark-shell -t spark-shell - < Dockerfile
     ```
 
 -   `spark-history-server`
 
     ``` {.bash}
-    docker build --build-target spark-history-server -t spark-history-server -f
+    docker build --target spark-history-server -t spark-history-server - <
     Dockerfile
     ```
 

--- a/doc/TODO.md
+++ b/doc/TODO.md
@@ -2,7 +2,6 @@
   history server
 - [] Fixen sectienummering
 - [] Toevoegen lab 1 boilerplate aan repo
-- [] Waar nodig lab 1 en example aanpassen aan tekst in manual (ivm Docker)
 - [] Assignment 1 aanpassen met duidelijke probleemstelling
   - Alleen het scala file mag worden aangepast
 - [] Hoe gaan we de exercise distributen? Moeten ze clonen/forken of zetten we

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -26,3 +26,9 @@ project/plugins/project/
 
 
 # End of https://www.gitignore.io/api/scala
+
+# Docker cache
+.ivy2
+.sbt
+.cache
+spark-events

--- a/example/build.sbt
+++ b/example/build.sbt
@@ -1,10 +1,10 @@
-ThisBuild / scalaVersion := "2.11.12"
+name := "Example"
 
-lazy val example = (project in file("."))
-  .settings(
-    name := "Example project",
-    fork in run := true,
+scalaVersion := "2.11.12"
 
-    libraryDependencies += "org.apache.spark" %% "spark-core" % "2.3.1",
-    libraryDependencies += "org.apache.spark" %% "spark-sql" % "2.3.1" 
-  )
+val sparkVersion = "2.4.4"
+
+libraryDependencies ++= Seq(
+  "org.apache.spark" %% "spark-core" % sparkVersion,
+  "org.apache.spark" %% "spark-sql" % sparkVersion
+)

--- a/example/project/build.properties
+++ b/example/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.1
+sbt.version=1.2.8


### PR DESCRIPTION
I somehow messed up the `--build-target` argument, which should be `--target`.

I also updated some run instructions to run them in containers, and I've added a short instruction on running the history server.

I also updated the `example` project to make sure it works with the Spark images based on the Dockerfile we provide.